### PR TITLE
Полная поддержка обработчиков которые унаследованы от UnityEngine.Object

### DIFF
--- a/Assets/Source/Experimental/Event/EventAggregator.cs
+++ b/Assets/Source/Experimental/Event/EventAggregator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using Omega.Tools.Experimental.Event;
 using Omega.Tools.Experimental.Events.Internals;
+using Object = UnityEngine.Object;
 
 namespace Omega.Tools.Experimental.Events
 {
@@ -12,12 +13,24 @@ namespace Omega.Tools.Experimental.Events
 
         public static IEnumerator EventAsync<TEvent>(TEvent arg)
             => EventManagerDispatcher<TEvent>.GetEventManager().EventAsync(arg);
-        
+
+
         public static void AddHandler<TEvent>(IEventHandler<TEvent> handler)
-            => EventManagerDispatcher<TEvent>.GetEventManager().AddHandler(handler);
+        {
+            if (handler is Object target)
+                handler = new UnityHandlerAdapter<TEvent>(handler, target);
+            
+            EventManagerDispatcher<TEvent>.GetEventManager().AddHandler(handler);
+        }
+
         public static void RemoveHandler<TEvent>(IEventHandler<TEvent> handler)
-            => EventManagerDispatcher<TEvent>.GetEventManager().RemoveHandler(handler);
-        
+        {
+            if (handler is Object target)
+                handler = new UnityHandlerAdapter<TEvent>(handler, target);
+            
+            EventManagerDispatcher<TEvent>.GetEventManager().RemoveHandler(handler);
+        }
+
         public static void AddHandler<TEvent>(Action<TEvent> handler)
         {
             var actionHandlerAdapter = ActionHandlerAdapterBuilder.Build(handler);

--- a/Assets/Source/Experimental/Event/UnityHandlerAdapter.cs
+++ b/Assets/Source/Experimental/Event/UnityHandlerAdapter.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Reflection;
+using Omega.Tools.Experimental.Events;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Omega.Tools.Experimental.Event
+{
+    public sealed class UnityHandlerAdapter<TEvent> : IEventHandler<TEvent>
+    {
+        private readonly IEventHandler<TEvent> _handler;
+        private readonly Object _targetObject;
+        private readonly InvocationConvention _invocationConvention;
+        public bool TargetObjectIsDestroyed => !_targetObject;
+
+        public UnityHandlerAdapter(IEventHandler<TEvent> handler)
+        {
+            _handler = handler;
+            _targetObject = handler as Object ?? throw new Exception();
+            _invocationConvention =
+                _targetObject.GetType().GetCustomAttribute<EventHandlerAttribute>()?.InvocationConvention ?? default;
+        }
+
+        public UnityHandlerAdapter(Object handler)
+        {
+            _handler = handler as IEventHandler<TEvent> ?? throw new Exception();
+            _targetObject = handler;
+            _invocationConvention =
+                _targetObject.GetType().GetCustomAttribute<EventHandlerAttribute>()?.InvocationConvention ?? default;
+        }
+        
+        internal UnityHandlerAdapter(IEventHandler<TEvent> handlerInterface, Object targetObject)
+        {
+            _handler = handlerInterface;
+            _targetObject = targetObject;
+            _invocationConvention =
+                _targetObject.GetType().GetCustomAttribute<EventHandlerAttribute>()?.InvocationConvention ?? default;
+        }
+        
+        public void Execute(TEvent arg)
+        {
+            if (TargetObjectIsDestroyed)
+                if (_invocationConvention == InvocationConvention.PreventInvocationFromDestroyedObject)
+                    throw new Exception(); //TODO
+                else if (_invocationConvention == InvocationConvention.AllowInvocationFromDestroyedObjectButLogWarning)
+                    Debug.LogWarning("TODO: write message"); //TODO
+
+            _handler.Execute(arg);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is UnityHandlerAdapter<TEvent> other && other._targetObject == _targetObject;
+        }
+
+        public override int GetHashCode()
+        {
+            return _targetObject.GetHashCode() + _invocationConvention.GetHashCode();
+        }
+    }
+}

--- a/Assets/Source/Experimental/Event/UnityHandlerAdapter.cs.meta
+++ b/Assets/Source/Experimental/Event/UnityHandlerAdapter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 41cb52b4d4b2418f99da56b0573d914d
+timeCreated: 1570967423

--- a/Assets/Tests/Runtime/Events/EventAggregatorTests.cs
+++ b/Assets/Tests/Runtime/Events/EventAggregatorTests.cs
@@ -1,0 +1,61 @@
+using System;
+using NUnit.Framework;
+using Omega.Tools.Experimental.Events.Internals;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Omega.Tools.Experimental.Events.Tests
+{
+    public class EventAggregatorTests
+    {
+        [Test]
+        public void AddHandlerShouldAddUnityObjectHandlerTest()
+        {
+            bool flag = false;
+
+            var gameObject = new GameObject(nameof(AddHandlerShouldAddUnityObjectHandlerTest));
+            var handler = gameObject.AddComponent<TestMonoBehaviour>();
+            handler.callback = () => flag = true;
+            
+            EventAggregator.AddHandler(handler);
+            EventAggregator.Event(new TestEvent());
+
+            Assert.True(flag);
+            
+            Object.DestroyImmediate(gameObject);
+        }
+        
+        [Test]
+        public void AddHandlerShouldRemoveUnityObjectHandlerTest()
+        {
+            var gameObject = new GameObject(nameof(AddHandlerShouldRemoveUnityObjectHandlerTest));
+            var handler = gameObject.AddComponent<TestMonoBehaviour>();
+            handler.callback = () => Assert.Fail();
+            
+            EventAggregator.AddHandler(handler);
+            EventAggregator.RemoveHandler(handler);
+            EventAggregator.Event(new TestEvent());
+
+            Object.DestroyImmediate(gameObject);
+        }
+
+        [SetUp]
+        [TearDown]
+        public void ClearHandlers()
+            => EventManagerDispatcher<TestEvent>.RemoveEventManagerInternal();
+        
+        private struct TestEvent
+        {
+        }
+
+        private class TestMonoBehaviour : MonoBehaviour, IEventHandler<TestEvent>
+        {
+            public Action callback;
+
+            public void Execute(TestEvent arg)
+            {
+                callback.Invoke();
+            }
+        }
+    }
+}

--- a/Assets/Tests/Runtime/Events/EventAggregatorTests.cs.meta
+++ b/Assets/Tests/Runtime/Events/EventAggregatorTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b7cb599e245f4cff8ca00d2bbb8523ba
+timeCreated: 1570991764


### PR DESCRIPTION
Теперь, если в методы `EventAggregator<TEvent>.AddHandler` /  `EventAggregator<TEvent>.RemoveHandler` передать объект, который реализовывает интерфейс `IEventHandler<TEvent>` и при этом сам имеет наследника `UnityEngine.Object`, то такой обработчик, перед вызовом, будет проверятся на валидность (на то что объект не является уничтоженным), и только после проверки, если политика вызова для этого обработчика, позовляет вызвать метод интерфейса, то он будет вызван. 